### PR TITLE
Truncate model names in thread metadata

### DIFF
--- a/portal/Models/Data.swift
+++ b/portal/Models/Data.swift
@@ -207,16 +207,18 @@ final class Thread {
     @Attribute(.unique) var id: UUID
     var title: String?
     var timestamp: Date
-    
+    var modelName: String?
+
     @Relationship var messages: [Message] = []
-    
+
     var sortedMessages: [Message] {
         return messages.sorted { $0.timestamp < $1.timestamp }
     }
-    
-    init() {
+
+    init(modelName: String? = nil) {
         self.id = UUID()
         self.timestamp = Date()
+        self.modelName = modelName
     }
 }
 

--- a/portal/Models/RequestLLMIntent.swift
+++ b/portal/Models/RequestLLMIntent.swift
@@ -53,7 +53,8 @@ struct RequestLLMIntent: AppIntent {
 
         if let modelName = appManager.currentModelName {
             _ = try? await llm.load(modelName: modelName)
-            
+            thread.modelName = modelName
+
             let message = Message(role: .user, content: prompt, thread: thread)
             thread.messages.append(message)
             var output = await llm.generate(modelName: modelName, thread: thread, systemPrompt: appManager.systemPrompt + systemPrompt)

--- a/portal/Views/Chat/ChatView.swift
+++ b/portal/Views/Chat/ChatView.swift
@@ -271,14 +271,16 @@ struct ChatView: View {
 
         if !isPromptEmpty {
             if currentThread == nil {
-                let newThread = Thread()
+                let newThread = Thread(modelName: activeModel)
                 currentThread = newThread
                 modelContext.insert(newThread)
-                try? modelContext.save()
             }
 
             if let currentThread = currentThread {
+                currentThread.modelName = activeModel
+                try? modelContext.save()
                 generatingThreadID = currentThread.id
+                let thread = currentThread
                 Task {
                     let message = prompt
                     #if os(iOS)
@@ -292,15 +294,15 @@ struct ChatView: View {
                     appManager.playHaptic()
                     sendMessage(
                         Message(
-                            role: .user, content: message, thread: currentThread,
+                            role: .user, content: message, thread: thread,
                             imageAttachments: savedImageURLs))
                     isPromptFocused = true
                     let output = await llm.generate(
-                        modelName: activeModel, thread: currentThread,
+                        modelName: activeModel, thread: thread,
                         systemPrompt: appManager.systemPrompt)
                     sendMessage(
                         Message(
-                            role: .assistant, content: output, thread: currentThread,
+                            role: .assistant, content: output, thread: thread,
                             generatingTime: llm.thinkingTime))
                     generatingThreadID = nil
                 }

--- a/portal/Views/Chat/ChatsListView.swift
+++ b/portal/Views/Chat/ChatsListView.swift
@@ -40,7 +40,7 @@ struct ChatsListView: View {
                             .foregroundStyle(.primary)
                             .font(.headline)
 
-                            Text(threadMetadata(for: thread))
+                            threadMetadata(for: thread)
                                 .foregroundStyle(.secondary)
                                 .font(.subheadline)
                                 .lineLimit(1)
@@ -179,24 +179,21 @@ struct ChatsListView: View {
         }
     }
 
-    private func threadMetadata(for thread: Thread) -> String {
-        if let modelName = thread.modelName, !modelName.isEmpty {
-            let displayName = appManager.modelDisplayName(modelName)
-            let truncatedName = truncatedModelName(displayName)
-            return "\(thread.timestamp.formatted()) · \(truncatedName)"
+    private func threadMetadata(for thread: Thread) -> Text {
+        let timestampText = Text(thread.timestamp.formatted())
+
+        guard let modelName = thread.modelName, !modelName.isEmpty else {
+            return timestampText
         }
 
-        return thread.timestamp.formatted()
-    }
+        let displayName = appManager.modelDisplayName(modelName)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
 
-    private func truncatedModelName(_ name: String) -> String {
-        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
-        let maxLength = 24
-        guard trimmed.count > maxLength else { return trimmed }
+        guard !displayName.isEmpty else {
+            return timestampText
+        }
 
-        let endIndex = trimmed.index(trimmed.startIndex, offsetBy: maxLength)
-        let shortened = String(trimmed[..<endIndex]).trimmingCharacters(in: .whitespacesAndNewlines)
-        return "\(shortened)…"
+        return timestampText + Text(" · \(displayName)")
     }
 }
 

--- a/portal/Views/Chat/ChatsListView.swift
+++ b/portal/Views/Chat/ChatsListView.swift
@@ -43,7 +43,6 @@ struct ChatsListView: View {
                             threadMetadata(for: thread)
                                 .foregroundStyle(.secondary)
                                 .font(.subheadline)
-                                .lineLimit(1)
                         }
                         #if os(macOS)
                             .swipeActions {
@@ -179,21 +178,32 @@ struct ChatsListView: View {
         }
     }
 
-    private func threadMetadata(for thread: Thread) -> Text {
-        let timestampText = Text(thread.timestamp.formatted())
+    @ViewBuilder
+    private func threadMetadata(for thread: Thread) -> some View {
+        let timestamp = thread.timestamp.formatted()
 
+        if let metadata = metadataString(for: thread, timestamp: timestamp) {
+            Text(verbatim: metadata)
+                .lineLimit(1)
+        } else {
+            Text(verbatim: timestamp)
+                .lineLimit(1)
+        }
+    }
+
+    private func metadataString(for thread: Thread, timestamp: String) -> String? {
         guard let modelName = thread.modelName, !modelName.isEmpty else {
-            return timestampText
+            return nil
         }
 
         let displayName = appManager.modelDisplayName(modelName)
             .trimmingCharacters(in: .whitespacesAndNewlines)
 
         guard !displayName.isEmpty else {
-            return timestampText
+            return nil
         }
 
-        return timestampText + Text(" · \(displayName)")
+        return "\(timestamp) · \(displayName)"
     }
 }
 


### PR DESCRIPTION
## Summary
- prevent chat metadata from wrapping by truncating long model display names with an ellipsis
- ensure the metadata label itself stays to a single line in the chat list

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_b_68e8233a91fc8326a323dac7a30b86ba